### PR TITLE
Update links to HTTPS

### DIFF
--- a/intence/index.html
+++ b/intence/index.html
@@ -6,27 +6,27 @@
 
     <meta property="og:title" content="Intence, a brand new way of scrolling indication" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="http://asvd.github.io/intence/" />
-    <meta property="og:image" content="http://asvd.github.io/intence/intence_preview.png" />
+    <meta property="og:url" content="https://asvd.github.io/intence/" />
+    <meta property="og:image" content="https://asvd.github.io/intence/intence_preview.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="262" />
     <meta property="og:image:height" content="200" />    
     <meta property="og:description" content="You will never wish to see the scrollbar again." />
 
     <link
-       href='http://fonts.googleapis.com/css?family=PT+Sans+Caption&subset=latin,cyrillic'
+       href='https://fonts.googleapis.com/css?family=PT+Sans+Caption&subset=latin,cyrillic'
        rel='stylesheet' type='text/css'>
 
     <link
-       href='http://fonts.googleapis.com/css?family=PT+Sans&subset=latin,cyrillic'
+       href='https://fonts.googleapis.com/css?family=PT+Sans&subset=latin,cyrillic'
        rel='stylesheet' type='text/css'>
 
     <link
-       href='http://fonts.googleapis.com/css?family=Amatic+SC'
+       href='https://fonts.googleapis.com/css?family=Amatic+SC'
        rel='stylesheet' type='text/css'>
 
     <link
-       href='http://fonts.googleapis.com/css?family=Special+Elite'
+       href='https://fonts.googleapis.com/css?family=Special+Elite'
        rel='stylesheet' type='text/css'>
 
 
@@ -88,7 +88,7 @@
     <div class=section_concept>
 
       <div class=lang>
-        <a href="http://asvd.github.io/intence_ru/">
+        <a href="https://asvd.github.io/intence_ru/">
           нажмите сюда
         </a>
       </div>
@@ -188,7 +188,7 @@
                      id="example_intro_area">
                   <div class=example_text>
 
-                    <a href="http://en.wikipedia.org/wiki/Event_horizon"
+                    <a href="https://en.wikipedia.org/wiki/Event_horizon"
                        target=_blank>
                       <img class="w" src="w.png"/>
                     </a>
@@ -1557,7 +1557,7 @@
 </div>
 
                     <div class="goethe_copy align_left">
-                      <a href="http://en.wikipedia.org/wiki/G%C3%B6tz_von_Berlichingen_(Goethe)" target=_blank>Götz von Berlichingen mit der eisernen Hand</a>
+                      <a href="https://en.wikipedia.org/wiki/G%C3%B6tz_von_Berlichingen_(Goethe)" target=_blank>Götz von Berlichingen mit der eisernen Hand</a>
                     </div>
 
                   </div>
@@ -3646,7 +3646,7 @@
 
           <div class="_700_80 float_left align_center advice">
             this is the Chinese
-            scroll <a href="http://en.wikipedia.org/wiki/Along_the_River_During_the_Qingming_Festival" target=_blank>Along
+            scroll <a href="https://en.wikipedia.org/wiki/Along_the_River_During_the_Qingming_Festival" target=_blank>Along
             the River</a>, in case you're wondering
           </div>
 
@@ -3716,7 +3716,7 @@
   like the menu on the right side. It can be a pager, or an area with
   small previews, a progress bar, or something totally new and
   different. For instance, have a look
-  at <a href="http://asvd.github.io/viewport/">some examples of the
+  at <a href="https://asvd.github.io/viewport/">some examples of the
   navigation components</a> created with a
   <a href="https://github.com/asvd/viewport">viewport.js
   library</a>. Just like as <span class=intenceName>intence</span>
@@ -4439,7 +4439,7 @@ document.getElementById('myElem').scroller.scrollTop;
           the <a href="https://github.com/asvd/viewport">viewport.js
           library</a> (the menu on this page uses that library, also
           have a look at
-          some <a href="http://asvd.github.io/viewport/">addititonal
+          some <a href="https://asvd.github.io/viewport/">addititonal
           examples</a>). Use <a href="https://github.com/asvd/naturalScroll">natural
           scroll</a> if your navigation component scrolls the viewport
           (by clicking on the menu item, for instance).


### PR DESCRIPTION
Those two links couldn't be updated:

* bower.io (issue reported https://github.com/bower/bower.github.io/issues/45)
* visibleearth.nasa.gov/view.php?id=73934 (not sure how to report it, as it's a gov website)

If there are HTTPS equivalent versions for those URLS prefer those.